### PR TITLE
2nd attempt to fix 'uncontrolled form' warning

### DIFF
--- a/client/src/components/Address.js
+++ b/client/src/components/Address.js
@@ -1,24 +1,5 @@
-import React, { useState, useEffect } from 'react';
-
 function Address(props) {
-  const { onChange: propsHandleChange } = props;
-  const {
-    address_1 = '',
-    address_2 = '',
-    city = '',
-    province = '',
-    postalcode = '',
-    country ='',
-    phone_number = ''
-  } = props.address;
-  const [ address, setAddress ] = useState({ address_1, address_2, city, province,
-                                             postalcode, country, phone_number });
-
-  useEffect(function() {
-    if (props.address.location !== null) {
-      setAddress({ ...props.address });
-    }
-  }, [props]);
+  const { address: propsAddress, onChange: propsHandleChange } = props;
 
   return (
     <fieldset>
@@ -26,26 +7,26 @@ function Address(props) {
       <div className='box'>
         <label htmlFor='address_1'>Address 1</label>
         <input type='text' id='address_1' name='address_1' placeholder='Address 1'
-          value={address.address_1} onChange={propsHandleChange} required />
+          value={propsAddress.address_1} onChange={propsHandleChange} required />
         <label htmlFor='address_2'>Address 2</label>
         <input type='text' id='address_2' name='address_2' placeholder='Address 2'
-          value={address.address_2} onChange={propsHandleChange} />
+          value={propsAddress.address_2} onChange={propsHandleChange} />
       </div>
       <label htmlFor='city'>City</label>
       <input type='text' id='city' name='city' placeholder='City' 
-        value={address.city} onChange={propsHandleChange} required /><br />
+        value={propsAddress.city} onChange={propsHandleChange} required /><br />
       <label htmlFor='province'>Province</label>
       <input type='text' id='province' name='province'
-        value={address.province} onChange={propsHandleChange} required /><br />
+        value={propsAddress.province} onChange={propsHandleChange} required /><br />
       <label htmlFor='postalcode'>Postal Code</label>
       <input type='text' id='postalcode' name='postalcode' placeholder='Postal Code' 
-        value={address.postalcode} onChange={propsHandleChange} required /><br />
+        value={propsAddress.postalcode} onChange={propsHandleChange} required /><br />
       <label htmlFor='country'>Country</label>
       <input type='text' id='country' name='country' 
-        value={address.country} onChange={propsHandleChange} required /><br />
+        value={propsAddress.country} onChange={propsHandleChange} required /><br />
       <label htmlFor='phone_number'>Phone Number</label>
       <input type='text' id='phone_number' name='phone_number' placeholder='Phone number' 
-        value={address.phone_number} onChange={propsHandleChange} required /><br />
+        value={propsAddress.phone_number} onChange={propsHandleChange} required /><br />
     </fieldset>
   );
 }

--- a/client/src/pages/ProfileEdit.js
+++ b/client/src/pages/ProfileEdit.js
@@ -6,7 +6,9 @@ import API from '../utils/API';
 function ProfileEdit(props) {
   const { type: propsType } = props.user;
   const { updateUser: propsUpdateUser } = props;
-  const [ profile, setProfile ] = useState({ name:'', bio:'', address: {location: null} });
+  const [ profile, setProfile ] = useState({ name:'', bio:'', address: {
+      address_1:'', address_2:'', city:'', province:'', postalcode:'',
+      country:'', phone_number:'', location:null }});
   const [ errorMsg, setErrorMsg ] = useState('');
   const history = useHistory();
 
@@ -14,8 +16,20 @@ function ProfileEdit(props) {
     API.getProfile((res) => {
       if (res.status) {
         // Ignore the bio field for customers
-        const { name, address, bio = '' } = res;
-        setProfile({ name, address, bio });
+        const { name, bio = '', address: {
+          address_1 = '',
+          address_2 = '',
+          city = '',
+          province = '',
+          postalcode = '',
+          country ='',
+          phone_number = '',
+          location = null
+        } } = res;
+        setProfile({ name, bio, address: {
+          address_1, address_2, city, province, postalcode,
+          country, phone_number, location
+        } });
       } else {
         setErrorMsg(res.message);
       }

--- a/dao/ArtistsDAO.js
+++ b/dao/ArtistsDAO.js
@@ -15,7 +15,7 @@ class ArtistsDAO {
   }
 
   static createProfile() {
-    return artists.insertOne({ name: null, bio: null, address: { location: null } });
+    return artists.insertOne({ name: '', bio: '', address: { location: null } });
   }
 
   static getProfile(id) {

--- a/dao/CustomersDAO.js
+++ b/dao/CustomersDAO.js
@@ -15,7 +15,7 @@ class CustomersDAO {
   }
 
   static createProfile() {
-    return customers.insertOne({ name: null, address: { location: null } });
+    return customers.insertOne({ name: '', address: { location: null } });
   }
 
   static getProfile(id) {


### PR DESCRIPTION
2nd attempt to fix 'uncontrolled form' warning
Caused by name/bio being initialized to null when a new profile is created.
On entering profile values, name/bio changes from null to defined (either empty string or actual value). React doesn't like that.
Fix is to initialize name/bio to an empty string instead of null.